### PR TITLE
Resolve #3: Print OS specific help.

### DIFF
--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -60,8 +60,8 @@ const extractExample = `  mactool extract 0000.5e00.5301 00:00:5e:00:53:01 0000-
 Interactive mode:
   mactool extract
 
-While operating in interactive mode, enter or paste the input string and then press
-Enter to proceed. To exit, use Ctrl+D (Unix) or Ctrl+Z (Windows), followed by Enter.`
+Use interactive mode when you intend to conveniently paste and
+process output from a network device containing MAC addresses.`
 
 // Long help text for the extract command
 const extractLong = `Extract MAC addresses from the input string

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -114,7 +114,7 @@ Interactive mode:
   mactool format
 
 Use interactive mode when you intend to conveniently paste and
-format multiple MAC addresses from external sources.`
+process output from a network device containing MAC addresses.`
 
 // Long help text for the format command
 const formatLong = `The format command extracts MAC addresses from the input string,

--- a/cmd/lookup.go
+++ b/cmd/lookup.go
@@ -86,8 +86,8 @@ const lookupExample = `  mactool lookup 00:00:5e:00:53:01
 Interactive mode:
   mactool lookup
 
-While operating in interactive mode, enter or paste the input string and then press
-Enter to proceed. To exit, use Ctrl+D (Unix) or Ctrl+Z (Windows), followed by Enter.`
+Use interactive mode when you intend to conveniently paste and
+process output from a network device containing MAC addresses.`
 
 // Long help text for the lookup command
 const lookupLong = `Extract MAC addresses from the input string, perform


### PR DESCRIPTION
Since the command already prints the help every time you run the command there is no need:
```
mactool format
Please enter the input text. Press CTRL+Z to finish.
```

The help text has been generalized across commands.