### PR TITLE
Resolve #5: Default download path for oui.csv

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -84,8 +85,16 @@ func initConfig() {
 		viper.SetConfigName(".mactool")
 	}
 
+	// Check for environment variables prefixed with MACTOOL
+	replacer := strings.NewReplacer("-", "_")
+	viper.SetEnvKeyReplacer(replacer)
+	viper.SetEnvPrefix("MACTOOL")
+
 	// Load any environment variable that match an existing config key
 	viper.AutomaticEnv()
+
+	// Print all environment variables loaded in viper
+	// viper.Debug()
 
 	// If a config file is found, read it in.
 	viper.ReadInConfig()

--- a/oui/oui.go
+++ b/oui/oui.go
@@ -26,6 +26,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
 )
 
 // Oui represents an OUI entry in the database
@@ -147,4 +150,37 @@ func DownloadDatabase(w io.Writer, url string) error {
 
 	// No errors occurred during download
 	return nil
+}
+
+// GetDefaultDatabasePath returns the path to the OUI
+// database file based on the operating system:
+// Windows: %LOCALAPPDATA%\Mactool\oui.csv
+// Unix:    $HOME/.local/share/mactool/oui.csv
+func GetDefaultDatabasePath() string {
+	// Default OUI database file path
+	defaultOui := "oui.csv"
+
+	// Get the root of the users home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return defaultOui
+	}
+
+	// Get the path to the OUI database file
+	// based on the operating system
+	var dataDir string
+	if runtime.GOOS == "windows" {
+		dataDir = filepath.Join(homeDir, "AppData", "Local", "Mactool")
+	} else {
+		dataDir = filepath.Join(homeDir, ".local", "share", "mactool")
+	}
+
+	// Create the data directory if it doesn't exist
+	err = os.MkdirAll(dataDir, os.ModePerm)
+	if err != nil {
+		return defaultOui
+	}
+
+	// Return the path to the OUI database file
+	return filepath.Join(dataDir, "oui.csv")
 }


### PR DESCRIPTION
The CSV file can be specified using the following methods,
in order of precedence (1 is highest, 4 is lowest):

1. `--csv-file` flag
2. `MACTOOL_CSV_FILE` environment variable
3. `.mactool.yaml` config file, key `csv-file: "/path/to/csv.oui"`
4. Default CSV file path