### PR TITLE
Implement flags to allow for output to file

### DIFF
--- a/cmd/extract_test.go
+++ b/cmd/extract_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
+	"github.com/bitcanon/mactool/utils"
 	"github.com/spf13/viper"
 )
 
@@ -96,8 +98,8 @@ func TestExtractAction(t *testing.T) {
 			var output bytes.Buffer
 
 			// Set the sort flags
-			viper.Set("extract-sort-asc", test.sortAsc)
-			viper.Set("extract-sort-desc", test.sortDesc)
+			viper.Set("extract.sort-asc", test.sortAsc)
+			viper.Set("extract.sort-desc", test.sortDesc)
 
 			// Call the function to test
 			err := extractAction(&output, test.input)
@@ -111,6 +113,126 @@ func TestExtractAction(t *testing.T) {
 			// Compare the results to the expected values
 			if output.String() != test.expected {
 				t.Errorf("expected %q, but got %q", test.expected, output.String())
+			}
+		})
+	}
+}
+
+// TestExtractActionOutput tests the extractAction function
+// with the output and append options set and unset.
+func TestExtractActionOutput(t *testing.T) {
+	// Get a tempfile for the output
+	outputFile, err := os.CreateTemp("", "extract_output.txt")
+	if err != nil {
+		t.Errorf("error creating tempfile: %v", err)
+		return
+	}
+	defer os.Remove(outputFile.Name())
+
+	// Setup test cases
+	testCases := []struct {
+		name       string
+		input      string
+		expected   string
+		outputFile string
+		append     bool
+	}{
+		{
+			name:       "EmptyInput",
+			input:      "",
+			expected:   "",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInput",
+			input:      "First line of input with one MAC address 00:00:5e:00:53:01 in it.",
+			expected:   "00:00:5e:00:53:01\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name: "MultiLineInput",
+			input: `First line of input with one MAC address 00:00:5e:00:53:01 in it.
+			Second line of input with one MAC address 00-00-5E-00-53-02 in it.`,
+			expected:   "00:00:5e:00:53:01\n00-00-5E-00-53-02\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInputWithMultipleMacAddresses",
+			input:      "First MAC address 00:00:5e:00:53:01 and second MAC address 00-00-5E-00-53-02 in it.",
+			expected:   "00:00:5e:00:53:01\n00-00-5E-00-53-02\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name: "MultiLineInputWithNoMacAddresses",
+			input: `First line of input with no MAC address in it.
+			Second line of input with no MAC address in it.`,
+			expected:   "",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInputWithMultipleMacAddresses",
+			input:      "First MAC address 00:00:5e:00:53:01 and second MAC address 00-00-5E-00-53-02.",
+			expected:   "00:00:5e:00:53:01\n00-00-5E-00-53-02\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInputWithAppend",
+			input:      "First line of input with one MAC address 00:00:5e:00:53:01 in it.",
+			expected:   "00:00:5e:00:53:01\n00-00-5E-00-53-02\n00:00:5e:00:53:01\n",
+			outputFile: outputFile.Name(),
+			append:     true,
+		},
+		{
+			name:       "SingleLineInputWithMultipleMacAddressesAndAppend",
+			input:      "First MAC address 00:00:5e:00:53:01 and second MAC address 00-00-5E-00-53-02 in it.",
+			expected:   "00:00:5e:00:53:01\n00-00-5E-00-53-02\n00:00:5e:00:53:01\n00:00:5e:00:53:01\n00-00-5E-00-53-02\n",
+			outputFile: outputFile.Name(),
+			append:     true,
+		},
+	}
+
+	// Loop through the test cases and run each test
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Disable sorting for this test
+			viper.Set("extract.sort-asc", false)
+			viper.Set("extract.sort-desc", false)
+
+			// Set the output file
+			viper.Set("extract.output-file", test.outputFile)
+			viper.Set("extract.append", test.append)
+
+			// Get the output stream
+			outStream, err := utils.GetOutputStream(test.outputFile, test.append)
+			if err != nil {
+				t.Errorf("error getting output stream: %v", err)
+				return
+			}
+			defer outStream.Close()
+
+			// Call the function to test
+			err = extractAction(outStream, test.input)
+			if err != nil {
+				t.Errorf("error returned from extractAction(): %v", err)
+				return
+			}
+
+			// Read the output file using os.ReadFile()
+			actual, err := os.ReadFile(test.outputFile)
+			if err != nil {
+				t.Errorf("error reading output file: %v", err)
+				return
+			}
+
+			// Compare the results to the expected values
+			if string(actual) != test.expected {
+				t.Errorf("expected %q, but got %q", test.expected, string(actual))
 			}
 		})
 	}

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/bitcanon/mactool/mac"
+	"github.com/bitcanon/mactool/utils"
+	"github.com/spf13/viper"
 )
 
 // TestFormatAction tests the formatAction function.
@@ -23,7 +26,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 00-1A-2B-3C-4D-5E
 				And another one: AA-BB-CC-DD-EE-FF
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.Upper,
 				Delimiter: mac.Hyphen,
@@ -37,7 +40,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 00:1a:2b:3c:4d:5e
 				And another one: aa:bb:cc:dd:ee:ff
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.Lower,
 				Delimiter: mac.Colon,
@@ -51,7 +54,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 00.1A.2B.3C.4D.5E
 				And another one: AA.BB.CC.Dd.Ee.Ff
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.Dot,
@@ -65,7 +68,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 001A2B3C4D5E
 				And another one: AABBCCDDEEFF
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.None,
@@ -79,7 +82,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 00:1A:2B:3C:4D:5E
 				And another one: AA:BB:CC:DD:EE:FF
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.Colon,
@@ -93,7 +96,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 00-1A-2B-3C-4D-5E
 				And another one: AA-BB-CC-DD-EE-FF
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.Hyphen,
@@ -107,7 +110,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 00.1a.2b.3c.4d.5e
 				And another one: aa.bb.cc.dd.ee.ff
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.Lower,
 				Delimiter: mac.Dot,
@@ -121,7 +124,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 001A2B3C4D5E
 				And another one: AABBCCDDEEFF
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.Upper,
 				Delimiter: mac.None,
@@ -135,7 +138,7 @@ func TestFormatAction(t *testing.T) {
 				No MAC here: 123456`,
 			expected: `Here is a MAC address: 001A:2B3C:4D5E
 				And another one: 001A:2B3C:4D5E
-				No MAC here: 123456`,
+				No MAC here: 123456` + "\n",
 			format: mac.MacFormat{
 				Case:      mac.Upper,
 				Delimiter: mac.Colon,
@@ -162,5 +165,89 @@ func TestFormatAction(t *testing.T) {
 				t.Errorf("expected '%s'\n\nbut got '%s'", test.expected, actualOutput)
 			}
 		})
+	}
+}
+
+// TestFormatActionOutput tests the formatAction function
+// with the output and append options set and unset.
+func TestFormatActionOutput(t *testing.T) {
+	// Get a tempfile for the output
+	outputFile, err := os.CreateTemp("", "extract_output.txt")
+	if err != nil {
+		t.Errorf("error creating tempfile: %v", err)
+		return
+	}
+	defer os.Remove(outputFile.Name())
+
+	// Set up test cases
+	testCases := []struct {
+		name       string
+		input      string
+		expected   string
+		format     mac.MacFormat
+		outputFile string
+		append     bool
+	}{
+		{
+			name:       "EmptyInput",
+			input:      "",
+			expected:   "",
+			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: 2},
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInput",
+			input:      "Single line of input with one MAC address 00-00-5e-00-53-01 in it.",
+			expected:   "Single line of input with one MAC address 00:00:5e:00:53:01 in it." + "\n",
+			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: 2},
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name: "MultiLineInput",
+			input: `First line of input with one MAC address 00-00-5e-00-53-01 in it.
+Second line of input with one MAC address 00-00-5E-00-53-02 in it.`,
+			expected: `Single line of input with one MAC address 00:00:5e:00:53:01 in it.
+First line of input with one MAC address 00:00:5e:00:53:01 in it.
+Second line of input with one MAC address 00:00:5e:00:53:02 in it.` + "\n",
+			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: 2},
+			outputFile: outputFile.Name(),
+			append:     true,
+		},
+	}
+
+	// Loop through the test cases and run each test
+	for _, test := range testCases {
+		// Set the output file
+		viper.Set("format.output", test.outputFile)
+		viper.Set("format.append", test.append)
+
+		// Get the output stream
+		outStream, err := utils.GetOutputStream(test.outputFile, test.append)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+		defer outStream.Close()
+
+		// Call the function to test
+		err = formatAction(outStream, test.format, test.input)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+
+		// Read the output file using os.ReadFile()
+		actual, err := os.ReadFile(test.outputFile)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+
+		// Compare the output
+		if string(actual) != test.expected {
+			t.Errorf("expected '%s'\n\nbut got '%s'", test.expected, string(actual))
+		}
 	}
 }

--- a/cmd/lookup_test.go
+++ b/cmd/lookup_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/bitcanon/mactool/utils"
 	"github.com/spf13/viper"
 )
 
@@ -139,8 +141,8 @@ MA-L,123ABC,Swede Instruments,Storgatan 1 Stockholm SE 12345`
 			viper.Set("suppress-unmatched", test.suppress)
 
 			// Set the sort flags
-			viper.Set("lookup-sort-asc", test.sortAsc)
-			viper.Set("lookup-sort-desc", test.sortDesc)
+			viper.Set("lookup.sort-asc", test.sortAsc)
+			viper.Set("lookup.sort-desc", test.sortDesc)
 
 			// Prepare a buffer to capture the output
 			var output strings.Builder
@@ -159,4 +161,107 @@ MA-L,123ABC,Swede Instruments,Storgatan 1 Stockholm SE 12345`
 		})
 	}
 
+}
+
+func TestLookupActionOutput(t *testing.T) {
+	outputFile, err := os.CreateTemp("", "lookup_output.txt")
+	if err != nil {
+		t.Errorf("error creating tempfile: %v", err)
+		return
+	}
+	defer os.Remove(outputFile.Name())
+
+	// Setup test cases
+	testCases := []struct {
+		name       string
+		input      string
+		expected   string
+		outputFile string
+		append     bool
+	}{
+		{
+			name:       "SingleLineInput",
+			input:      "First line of input with one MAC address 00:00:5e:00:53:01 in it.",
+			expected:   "00:00:5e:00:53:01 (Banana, Inc.)\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name: "MultiLineInput",
+			input: `First line of input with one MAC address 00:00:5e:00:53:01 in it.
+			Second line of input with one MAC address 00-00-5E-00-53-02 in it.`,
+			expected:   "00:00:5e:00:53:01 (Banana, Inc.)\n00-00-5E-00-53-02 (Banana, Inc.)\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInputWithNoMacAddresses",
+			input:      "First line of input with no MAC address in it.",
+			expected:   "",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInputWithMultipleMacAddresses",
+			input:      `First MAC address 00:00:5e:11:11:11 and second MAC address 12-3A-BC-00-53-02 in it.`,
+			expected:   "00:00:5e:11:11:11 (Banana, Inc.)\n12-3A-BC-00-53-02 (Swede Instruments)\n",
+			outputFile: outputFile.Name(),
+			append:     false,
+		},
+		{
+			name:       "SingleLineInputWithAppend",
+			input:      "One MAC address 00:00:5e:22:22:22 in this line.",
+			expected:   "00:00:5e:11:11:11 (Banana, Inc.)\n12-3A-BC-00-53-02 (Swede Instruments)\n00:00:5e:22:22:22 (Banana, Inc.)\n",
+			outputFile: outputFile.Name(),
+			append:     true,
+		},
+	}
+
+	// Create a test CSV database, in memory, to be used by the test cases
+	csvData := `Registry,Assignment,Organization Name,Organization Address
+MA-L,00005E,"Banana, Inc.",1 Infinite Loop Cupocoffee CA US 12345
+MA-L,123ABC,Swede Instruments,Storgatan 1 Stockholm SE 12345`
+
+	// Loop through the test cases and run each test
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a reader for the test CSV database
+			reader := strings.NewReader(csvData)
+
+			// Disable sorting for this test
+			viper.Set("lookup.sort-asc", false)
+			viper.Set("lookup.sort-desc", false)
+
+			// Set the output file
+			viper.Set("lookup.output-file", test.outputFile)
+			viper.Set("lookup.append", test.append)
+
+			// Get the output stream
+			outStream, err := utils.GetOutputStream(test.outputFile, test.append)
+			if err != nil {
+				t.Errorf("error getting output stream: %v", err)
+				return
+			}
+			defer outStream.Close()
+
+			// Call the function to test
+			err = lookupAction(outStream, reader, test.input)
+			if err != nil {
+				t.Errorf("error returned from lookupAction(): %v", err)
+				return
+			}
+
+			// Read the output file using os.ReadFile()
+			actual, err := os.ReadFile(test.outputFile)
+			if err != nil {
+				t.Errorf("error reading output file: %v", err)
+				return
+			}
+
+			// Compare the results to the expected values
+			if string(actual) != test.expected {
+				t.Errorf("expected %q, but got %q", test.expected, string(actual))
+			}
+		})
+	}
 }

--- a/utils/output.go
+++ b/utils/output.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2023 Mikael Schultz <bitcanon@proton.me>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package utils
+
+import "os"
+
+// GetOutputStream returns an output stream for the specified filename
+// If the filename is empty, the standard output stream is returned
+// If the append flag is true, the file is opened for appending
+// If the append flag is false, the file is opened for writing
+func GetOutputStream(filename string, append bool) (*os.File, error) {
+	// fileMode controls how the file is opened
+	var fileMode int
+
+	// If no filename is specified, use standard output
+	if filename == "" {
+		return os.Stdout, nil
+	}
+
+	if append {
+		// If append is true, append to the file
+		fileMode = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	} else {
+		// If append is false, overwrite the file
+		fileMode = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	}
+
+	// Open the file for writing using the specified file mode
+	outStream, err := os.OpenFile(filename, fileMode, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the output stream
+	return outStream, nil
+}

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -1,0 +1,69 @@
+package utils_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitcanon/mactool/utils"
+)
+
+// TestGetOutputStream tests the GetOutputStream function
+func TestGetOutputStream(t *testing.T) {
+	// Write to stdout
+	t.Run("WriteToStdout", func(t *testing.T) {
+		outStream, err := utils.GetOutputStream("", false)
+		if err != nil {
+			t.Errorf("Expected no error, but got: %v", err)
+		}
+		if outStream != os.Stdout {
+			t.Errorf("Expected stdout, but got: %v", outStream)
+		}
+	})
+
+	// Write to file, overwrite
+	t.Run("CreateNewFile", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "test")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		outStream, err := utils.GetOutputStream(tempFile.Name(), false)
+		if err != nil {
+			t.Errorf("Expected no error, but got: %v", err)
+		}
+		if outStream == nil {
+			t.Errorf("Expected non-nil output stream")
+		}
+		defer outStream.Close()
+	})
+
+	// Write to file, append
+	t.Run("AppendToFile", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "test")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		outStream, err := utils.GetOutputStream(tempFile.Name(), true)
+		if err != nil {
+			t.Errorf("Expected no error, but got: %v", err)
+		}
+		if outStream == nil {
+			t.Errorf("Expected non-nil output stream")
+		}
+		defer outStream.Close()
+	})
+
+	// Invalid filename
+	t.Run("InvalidFilename", func(t *testing.T) {
+		outStream, err := utils.GetOutputStream("/invalid/path", false)
+		if err == nil {
+			t.Errorf("Expected error, but got nil")
+		}
+		if outStream != nil {
+			t.Errorf("Expected nil output stream")
+		}
+	})
+}


### PR DESCRIPTION
Implemented flags `--output` and `--append` for the commands `extract`, `format `and `lookup`.