### PR TITLE
Read input from file

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 )
 
-// processStdin reads all data from standard input
+// ProcessStdin reads all data from standard input
 // and returns the input as a string
 func ProcessStdin() (string, error) {
 	// Read all data from standard input
@@ -43,7 +43,7 @@ func ProcessStdin() (string, error) {
 	return string(input), nil
 }
 
-// processInteractiveInput processes the interactive input
+// ProcessInteractiveInput processes the interactive input
 // and extracts MAC addresses from the input string
 func ProcessInteractiveInput() (string, error) {
 	// A string for the user input
@@ -61,6 +61,39 @@ func ProcessInteractiveInput() (string, error) {
 	fmt.Fprintf(os.Stderr, "Please enter the input text. Press %s to finish.\n", eofKeys)
 
 	// Read each line from standard input as the user types
+	for scanner.Scan() {
+		input += fmt.Sprintf("%s\n", scanner.Text())
+	}
+
+	// Remove the trailing newline character
+	input = strings.TrimRight(input, "\n")
+
+	// Check for errors that may have occurred while reading
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	// Return the input string on success
+	return input, nil
+}
+
+// ProcessFile reads all data from the specified file
+// and returns the input as a string
+func ProcessFile(filename string) (string, error) {
+	// Open the input file
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	// Create a scanner to read from the file
+	scanner := bufio.NewScanner(file)
+
+	// A string for the file contents
+	var input string
+
+	// Read each line from the file
 	for scanner.Scan() {
 		input += fmt.Sprintf("%s\n", scanner.Text())
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -137,3 +137,60 @@ Second line of input from interactive user input`,
 		})
 	}
 }
+
+// TestProcessFile tests the ProcessFile function
+// by creating a temporary file and writing test
+// data to it to simulate user input. The content
+// of the file is then read and compared to the
+// expected values
+func TestProcessFile(t *testing.T) {
+	// Test to read a file
+	t.Run("ReadFile", func(t *testing.T) {
+		content := "Line 1\nLine 2\nLine 3"
+		tempFile, err := os.CreateTemp("", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+		defer tempFile.Close()
+
+		_, err = tempFile.WriteString(content)
+		if err != nil {
+			t.Fatalf("failed to write to temp file: %v", err)
+		}
+
+		input, err := cli.ProcessFile(tempFile.Name())
+		if err != nil {
+			t.Errorf("fxpected no error, but got %v", err)
+		}
+		if input != content {
+			t.Errorf("expected content:\n'%s'\n\nbut got:\n'%s'", content, input)
+		}
+	})
+
+	// Test to read a file that does not exist
+	t.Run("FileNotFound", func(t *testing.T) {
+		_, err := cli.ProcessFile("nonexistent.txt")
+		if err == nil {
+			t.Errorf("expected error, but got nil")
+		}
+	})
+
+	// Test to read an empty file
+	t.Run("EmptyFile", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+		defer tempFile.Close()
+
+		input, err := cli.ProcessFile(tempFile.Name())
+		if err != nil {
+			t.Errorf("expected no error, but got: %v", err)
+		}
+		if input != "" {
+			t.Errorf("expected empty input, but got: %s", input)
+		}
+	})
+}

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -90,8 +90,14 @@ var extractCmd = &cobra.Command{
 		var input string
 		var err error
 
-		// Check if data is being piped or redirected to stdin
-		if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
+		// Check if data is being piped, read from file or redirected to stdin
+		if viper.GetString("extract.input") != "" {
+			// Read input from file
+			input, err = cli.ProcessFile(viper.GetString("extract.input"))
+			if err != nil {
+				return err
+			}
+		} else if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
 			// Process data from pipe or redirection (stdin)
 			input, err = cli.ProcessStdin()
 			if err != nil {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -136,8 +136,14 @@ var formatCmd = &cobra.Command{
 		var input string
 		var err error
 
-		// Check if data is being piped or redirected to stdin
-		if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
+		// Check if data is being piped, read from file or redirected to stdin
+		if viper.GetString("format.input") != "" {
+			// Read input from file
+			input, err = cli.ProcessFile(viper.GetString("format.input"))
+			if err != nil {
+				return err
+			}
+		} else if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
 			// Process data from pipe or redirection (stdin)
 			input, err = cli.ProcessStdin()
 			if err != nil {

--- a/cmd/lookup.go
+++ b/cmd/lookup.go
@@ -121,8 +121,14 @@ var lookupCmd = &cobra.Command{
 		var input string
 		var err error
 
-		// Check if data is being piped or redirected to stdin
-		if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
+		// Check if data is being piped, read from file or redirected to stdin
+		if viper.GetString("lookup.input") != "" {
+			// Read input from file
+			input, err = cli.ProcessFile(viper.GetString("lookup.input"))
+			if err != nil {
+				return err
+			}
+		} else if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
 			// Process data from pipe or redirection (stdin)
 			input, err = cli.ProcessStdin()
 			if err != nil {


### PR DESCRIPTION
Implemented the `--input` flag to read input from a file.
It works for the commands: `extract`, `format `and `lookup`.