### PR TITLE
Resolve #9: Save lookups to CSV file

### DIFF
--- a/utils/csv.go
+++ b/utils/csv.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/csv"
+)
+
+// ConvertStringSliceToCSV converts a string slice to a CSV-formatted string
+func ConvertStringSliceToCSV(data []string) (string, error) {
+	// Create a buffer to write CSV data to
+	var csvBuffer bytes.Buffer
+
+	// If the data slice is empty, return an empty string
+	if len(data) == 0 {
+		return "", nil
+	}
+
+	// Create a new CSV writer that writes to the buffer
+	csvWriter := csv.NewWriter(&csvBuffer)
+
+	// Write the string slice as a CSV record using WriteAll
+	err := csvWriter.WriteAll([][]string{data})
+	if err != nil {
+		return "", err
+	}
+
+	// Get the CSV-formatted string from the buffer
+	csvString := csvBuffer.String()
+
+	// Return the CSV-formatted string
+	return csvString, nil
+}

--- a/utils/csv_test.go
+++ b/utils/csv_test.go
@@ -1,0 +1,65 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/bitcanon/mactool/utils"
+)
+
+// TestConvertStringSliceToCSV tests the ConvertStringSliceToCSV function
+// using values containing characters that need to be escaped in CSV
+func TestConvertStringSliceToCSV(t *testing.T) {
+	// Setup test cases
+	testCases := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			name:     "EmptyInput",
+			input:    []string{},
+			expected: "",
+		},
+		{
+			name:     "SingleValue",
+			input:    []string{"value1"},
+			expected: "value1\n",
+		},
+		{
+			name:     "MultipleValues",
+			input:    []string{"value1", "value2", "value3"},
+			expected: "value1,value2,value3\n",
+		},
+		{
+			name:     "MultipleValuesWithCommas",
+			input:    []string{"value1", "value,2", "value3"},
+			expected: "value1,\"value,2\",value3\n",
+		},
+		{
+			name:     "MultipleValuesWithQuotes",
+			input:    []string{"value1", "value\"2", "value3"},
+			expected: "value1,\"value\"\"2\",value3\n",
+		},
+		{
+			name:     "MultipleValuesWithQuotesAndCommas",
+			input:    []string{"value1", "value,\"2", "value3"},
+			expected: "value1,\"value,\"\"2\",value3\n",
+		},
+	}
+
+	// Loop through test cases
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Convert the string slice to CSV
+			csvFormatted, err := utils.ConvertStringSliceToCSV(testCase.input)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			// Check if the CSV-formatted string matches the expected string
+			if csvFormatted != testCase.expected {
+				t.Errorf("expected:\n'%s'\ngot:\n'%s'", testCase.expected, csvFormatted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented the `--csv` flag for the `lookup `command.
When the flag is set the output is formatted as CSV strings (both when printing to stdout and file).