### PR TITLE
Resolve #30: Format command without flags

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -57,11 +57,22 @@ func createMacFormatFromFlags(upper bool, lower bool, delimiter string, groupSiz
 		delimiterOption = mac.None
 	}
 
+	// Select group size based on flags
+	groupSizeOption := mac.OriginalGroupSize
+	switch groupSize {
+	case 2:
+		groupSizeOption = mac.GroupSizeTwo
+	case 4:
+		groupSizeOption = mac.GroupSizeFour
+	case 6:
+		groupSizeOption = mac.GroupSizeSix
+	}
+
 	// Create a MacFormat struct from the flags
 	return mac.MacFormat{
 		Case:      caseOption,
 		Delimiter: delimiterOption,
-		GroupSize: groupSize,
+		GroupSize: groupSizeOption,
 	}
 }
 
@@ -211,7 +222,7 @@ func init() {
 	viper.BindPFlag("format.delimiter", formatCmd.Flags().Lookup("delimiter"))
 
 	// Add the --group-size flag to the format command
-	formatCmd.Flags().IntP("group-size", "g", 2, "number of characters in each hex group")
+	formatCmd.Flags().IntP("group-size", "g", 0, "number of characters in each hex group")
 	viper.BindPFlag("format.group-size", formatCmd.Flags().Lookup("group-size"))
 
 	// Add flag for input file path

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -20,6 +20,20 @@ func TestFormatAction(t *testing.T) {
 		format   mac.MacFormat
 	}{
 		{
+			name: "FormatUnmodified",
+			input: `Here is a MAC address: 00-1A-2B-3C-4D-5E
+				And another one: AA-BB-CC-DD-EE-FF
+				No MAC here: 123456`,
+			expected: `Here is a MAC address: 00-1A-2B-3C-4D-5E
+				And another one: AA-BB-CC-DD-EE-FF
+				No MAC here: 123456` + "\n",
+			format: mac.MacFormat{
+				Case:      mac.OriginalCase,
+				Delimiter: mac.OriginalDelim,
+				GroupSize: mac.OriginalGroupSize,
+			},
+		},
+		{
 			name: "FormatHyphenUpper",
 			input: `Here is a MAC address: 00:1A:2B:3C:4D:5E
 				And another one: AA-BB-CC-DD-EE-FF
@@ -30,7 +44,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.Upper,
 				Delimiter: mac.Hyphen,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -44,7 +58,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.Lower,
 				Delimiter: mac.Colon,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -58,7 +72,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.Dot,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -72,7 +86,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.None,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -86,7 +100,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.Colon,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -100,7 +114,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.OriginalCase,
 				Delimiter: mac.Hyphen,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -114,7 +128,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.Lower,
 				Delimiter: mac.Dot,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -128,7 +142,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.Upper,
 				Delimiter: mac.None,
-				GroupSize: 2,
+				GroupSize: mac.OriginalGroupSize,
 			},
 		},
 		{
@@ -142,7 +156,7 @@ func TestFormatAction(t *testing.T) {
 			format: mac.MacFormat{
 				Case:      mac.Upper,
 				Delimiter: mac.Colon,
-				GroupSize: 4,
+				GroupSize: mac.GroupSizeFour,
 			},
 		},
 	}
@@ -200,7 +214,7 @@ func TestFormatActionOutput(t *testing.T) {
 			name:       "SingleLineInput",
 			input:      "Single line of input with one MAC address 00-00-5e-00-53-01 in it.",
 			expected:   "Single line of input with one MAC address 00:00:5e:00:53:01 in it." + "\n",
-			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: 2},
+			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: mac.OriginalGroupSize},
 			outputFile: outputFile.Name(),
 			append:     false,
 		},
@@ -211,7 +225,7 @@ Second line of input with one MAC address 00-00-5E-00-53-02 in it.`,
 			expected: `Single line of input with one MAC address 00:00:5e:00:53:01 in it.
 First line of input with one MAC address 00:00:5e:00:53:01 in it.
 Second line of input with one MAC address 00:00:5e:00:53:02 in it.` + "\n",
-			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: 2},
+			format:     mac.MacFormat{Case: mac.Lower, Delimiter: mac.Colon, GroupSize: mac.OriginalGroupSize},
 			outputFile: outputFile.Name(),
 			append:     true,
 		},

--- a/mac/mac.go
+++ b/mac/mac.go
@@ -55,11 +55,45 @@ const (
 	None
 )
 
+// GroupSizeOption is used to specify the number of characters in each group.
+type GroupSizeOption int
+
+const (
+	OriginalGroupSize GroupSizeOption = iota
+	Two
+	Four
+	Six
+)
+
 // MacFormat is used to specify the format of the MAC address.
 type MacFormat struct {
 	Case      CaseOption
 	Delimiter DelimiterOption
 	GroupSize int
+}
+
+// getGroupSize calculates the group size of the MAC address.
+// The group size is the number of characters in each group.
+// A delimiting character separates each group, and can be any
+// character except alphanumeric characters.
+func getGroupSize(macAddress string) (int, error) {
+	// Remove all non-alphanumeric characters from the MAC address
+	strippedMAC := regexp.MustCompile(`[^0-9a-zA-Z]`).ReplaceAllString(macAddress, "")
+	strippedLen := len(strippedMAC)
+
+	// Calculate the number of delimiters removed from the MAC address
+	difference := len(macAddress) - strippedLen
+
+	// If the difference is 0, the MAC address is invalid
+	if difference == 0 {
+		return 0, ErrInvalidMacAddress
+	}
+
+	// Calculate the group size
+	groupSize := strippedLen / (difference + 1)
+
+	// Return the group size and no error
+	return groupSize, nil
 }
 
 // cleanMacAddress removes all non-alphanumeric characters from the MAC address.

--- a/mac/mac_test.go
+++ b/mac/mac_test.go
@@ -272,3 +272,43 @@ func TestFormatMacAddress(t *testing.T) {
 		})
 	}
 }
+
+// TestGetGroupSize tests the getGroupSize function.
+func TestGetGroupSize(t *testing.T) {
+	// Setup test cases
+	testCases := []struct {
+		name        string
+		macAddress  string
+		expected    int
+		expectedErr error
+	}{
+		{"WithColonGroupSizeIs2", "00:11:22:33:44:55", 2, nil},
+		{"WithHyphenGroupSizeIs2", "00-11-22-33-44-55", 2, nil},
+		{"WithPeriodGroupSizeIs2", "00.11.22.33.44.55", 2, nil},
+		{"WithColonGroupSizeIs4", "0011:2233:4455", 4, nil},
+		{"WithHyphenGroupSizeIs4", "0011-2233-4455", 4, nil},
+		{"WithPeriodGroupSizeIs4", "0011.2233.4455", 4, nil},
+		{"WithColonGroupSizeIs6", "001122:334455", 6, nil},
+		{"WithHyphenGroupSizeIs6", "001122-334455", 6, nil},
+		{"WithPeriodGroupSizeIs6", "001122.334455", 6, nil},
+		{"WithPeriodGroupSizeIs3", "001.122:334-455", 3, nil},
+		{"NoDelimiter", "001122334455", 0, ErrInvalidMacAddress},
+	}
+
+	// Loop through the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Get the group size of the MAC address
+			actual, err := getGroupSize(tc.macAddress)
+
+			// Compare the results to the expected values
+			if err != tc.expectedErr {
+				t.Errorf("expected %v, but got %v", tc.expectedErr, err)
+			}
+
+			if actual != tc.expected {
+				t.Errorf("expected %d, but got %d", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Formatted MAC addresses are now only modified when explicitly told so by flags.