### PR TITLE
Resolve #32: Format has default delimiter set

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -218,7 +218,7 @@ func init() {
 	viper.BindPFlag("format.lower", formatCmd.Flags().Lookup("lower"))
 
 	// Add the --delimiter flag to the format command
-	formatCmd.Flags().StringP("delimiter", "d", ":", "delimiter character to use between hex groups")
+	formatCmd.Flags().StringP("delimiter", "d", "=", "delimiter character to use between hex groups")
 	viper.BindPFlag("format.delimiter", formatCmd.Flags().Lookup("delimiter"))
 
 	// Add the --group-size flag to the format command

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -34,6 +34,20 @@ func TestFormatAction(t *testing.T) {
 			},
 		},
 		{
+			name: "FormatCleanMacUnmodified",
+			input: `Here is a MAC address: 001A2B3C4D5E
+				And another one: AABBCCDDEEFF
+				No MAC here: 123456`,
+			expected: `Here is a MAC address: 001A2B3C4D5E
+				And another one: AABBCCDDEEFF
+				No MAC here: 123456` + "\n",
+			format: mac.MacFormat{
+				Case:      mac.OriginalCase,
+				Delimiter: mac.OriginalDelim,
+				GroupSize: mac.OriginalGroupSize,
+			},
+		},
+		{
 			name: "FormatHyphenUpper",
 			input: `Here is a MAC address: 00:1A:2B:3C:4D:5E
 				And another one: AA-BB-CC-DD-EE-FF


### PR DESCRIPTION
The default is now to leave delimiter, group size and case unchanged unless told otherwise by flags.